### PR TITLE
Added support for the Lotek DigiBabel receiver (for FSK LifeTags)

### DIFF
--- a/rules.d/20-usb-hub-devices.rules
+++ b/rules.d/20-usb-hub-devices.rules
@@ -1,0 +1,329 @@
+# Copyright 2012-2017 john brzustowski (sensorgnome.org)
+# Portions Copyright 2012-2013 Osmocom rtl-sdr project
+# Portions Copyright 2021-2022 Thorsten von Eicken
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+# Detect devices attached to the USB hub or directly to the rPi.
+# We need to know which USB port each device is in, so we can
+# label data streams appropriately.
+# (e.g. assign a physical antenna or microphone ID to each audio stream)
+#
+# Disk drives:
+#   mount under /media/disk.port=X.name=Y
+#   make alias at /dev/sensorgnome/disk.port=X.name=Y
+#
+# GPS:
+#   make alias at /dev/sensorgnome/gps.port=X
+#
+# Audio device (e.g. funcube)
+#   make alias at /dev/sensorgnome/DDD.port=X.alsaDev=Y.usbPath=Z
+#   where DDD is one of:
+#    funcubePro
+#    funcubeProPlus
+#    usbAudio
+#
+# RTLSDR dvb dongle
+#   make alias at /dev/sensorgnome/rtlsdr.port=X.usbPath=Z
+#
+# Heavily modified from Arch linux file media-by-label-auto-mount.rules
+
+# This file has been heavily modified by TvE for the Sensorgnome V2:
+# - remove actions for USB hubs, we no longer detect them, the port mapping process has changed
+# - remove disk detection, we don't support plugging a USB stick in and expecting the data to
+#   be written to it
+# - primarily process additions, removals happen automatically in that udev removes symlinks
+# For troubleshooting:
+#  - sudo udevadm 
+
+# uncomment the following block for debug info
+#RUN{program}+="/usr/bin/logger -t sensorgnome vvvvvvvvvvvvvvvvvvv udev action=%a for %p"
+#ACTION=="add",RUN{program}+="/usr/bin/logger -t sensorgnome DBG action=Add %p %E{SUBSYSTEM} k=%k %M/%m %s{idVendor}:%s{idProduct}"
+#ACTION=="remove",RUN{program}+="/usr/bin/logger -t sensorgnome DBG action=remove %p %k %M %m %s{busnum} %s{devnum} %s{idVendor}:%s{idProduct}"
+#ACTION=="change",RUN{program}+="/usr/bin/logger -t sensorgnome DBG action=change %p %k"
+#ACTION=="bind",RUN{program}+="/usr/bin/logger -t sensorgnome DBG action=bind %p %k"
+#ACTION=="unbind",RUN{program}+="/usr/bin/logger -t sensorgnome DBG action=unbind %p %k"
+
+MODE:="0666"
+
+###################  START OF DISK DETECTION #####################
+
+# KERNEL!="sd[a-z][0-9]",KERNEL!="sd[a-z]",GOTO="not_disk"
+# ACTION!="add", GOTO="not_add_disk"
+# # don't try to mount the root device itself
+# KERNEL!="sd[a-z][0-9]",GOTO="done"
+# IMPORT{program}="/sbin/blkid -o udev -p %N"
+# IMPORT{program}="/opt/sensorgnome/udev-usb/get-usb-port.py %p"
+# 
+# # Disk: import FS info
+# ENV{mount_dir}="disk_port%E{PORT_NUM}-%n"
+# ENV{disk_name}="disk.port=%E{PORT_NUM}.name=%k.mount=%E{mount_dir}"
+# # Global mount options
+# ENV{mount_options}="defaults,noatime,users"
+# # Filesystem-specific mount options
+# ENV{ID_FS_TYPE}=="vfat",ENV{mount_options}="%E{mount_options},gid=100,umask=002,utf8,flush"
+# ENV{ID_FS_TYPE}=="ext4",ENV{mount_options}="%E{mount_options},group,users,suid"
+# ENV{ID_FS_TYPE}=="ntfs",ENV{mount_options}="%E{mount_options},gid=100,umask=002,utf8 -tntfs-3g"
+# SYMLINK+="sensorgnome/%E{disk_name}"
+# 
+# # Mount the device
+# ENV{PORT_NUM}!="",RUN+="/usr/bin/mkdir -p /media/%E{mount_dir}"
+# ENV{PORT_NUM}!="",RUN+="/usr/bin/mount -o %E{mount_options} /dev/%k /media/%E{mount_dir}"
+# ENV{PORT_NUM}!="",RUN+="/usr/bin/logger -t sensorgnome Mounted /dev/%k on /media/%E{mount_dir} options %E{mount_options}"
+# GOTO="done"
+# 
+# LABEL="not_add_disk"
+# # Clean up after removal
+# ACTION!="remove",GOTO="done"
+# IMPORT{program}="/opt/sensorgnome/udev-usb/get-usb-port.py %p"
+# ENV{mount_dirs}="disk_port%E{PORT_NUM}*"
+# ENV{PORT_NUM}!="",RUN+="/bin/sh -c 'for DEV in /media/%E{mount_dirs}; do umount -l /dev/%k; rmdir /media/%E{mount_dir}; done'"
+# GOTO="done"
+
+###################  END OF DISK DETECTION #####################
+LABEL="not_disk"
+################# START OTHER DEVICE DETECTION #################
+
+## detect funcube dongles
+SUBSYSTEMS=="usb",ATTRS{idVendor}=="04d8",ATTRS{idProduct}=="fb56",ENV{MYDEVNAME}="funcubePro",GOTO="usbaudio"
+SUBSYSTEMS=="usb",ATTRS{idVendor}=="04d8",ATTRS{idProduct}=="fb31",ENV{MYDEVNAME}="funcubeProPlus",GOTO="usbaudio"
+
+## detect Cornell tag XCVR / CTT LifeTag MOTUS Adapter
+SUBSYSTEM=="tty",ATTRS{idVendor}=="0403",ATTRS{idProduct}=="6001",ENV{MYDEVNAME}="CornellTagXCVR",GOTO="CornellTagXCVR"
+SUBSYSTEM=="tty",ATTRS{idVendor}=="0403",ATTRS{idProduct}=="6010",ENV{MYDEVNAME}="CornellTagXCVR",GOTO="CornellTagXCVR"
+# CTT Motus Adapter v1 with integrated CP2102 serial adapter and std Vid:Pid (ugh!)
+SUBSYSTEM=="tty",ATTRS{idVendor}=="10c4",ATTRS{idProduct}=="ea60",ENV{MYDEVNAME}="CornellTagXCVR",GOTO="CornellTagXCVR"
+# CTT Motus Adapter v2 made with Adafruit Feather #3077 using std Vid:Pid (ugh!)
+SUBSYSTEM=="tty",ATTRS{idVendor}=="239a",ATTRS{idProduct}=="800c",ENV{MYDEVNAME}="CornellTagXCVR",GOTO="CornellTagXCVR"
+
+## detect DigiBabel UHF FSK Tag Receiver
+# DigiBabel uses FTDI FT230X (VID=0403, PID=6015) at 230400 baud
+SUBSYSTEM=="tty",ATTRS{idVendor}=="0403",ATTRS{idProduct}=="6015",ENV{MYDEVNAME}="DigiBabel",GOTO="DigiBabel"
+
+## detect PL2303 serial port and assume it's a GPS (FIXME!)
+SUBSYSTEMS=="usb",ATTRS{idVendor}=="067b",ATTRS{idProduct}=="2303",KERNEL=="tty*",GOTO="pl2303gps"
+
+## detect sensorgnome PPSGPS (with our own custom local VID/PID)
+SUBSYSTEMS=="usb",ATTRS{idVendor}=="bd09",ATTRS{idProduct}=="0001",GOTO="sg_ppsgps"
+
+## any other sound device is assumed to be USB audio
+SUBSYSTEMS=="sound",ENV{MYDEVNAME}="usbAudio",GOTO="usbaudio"
+
+## otherwise, see whether it's an rtlsdr dongle
+GOTO="rtlsdr"
+
+# Cornell (Gabrielson & Winkler) Tag Transceiver / CTT LifeTag MOTUS Adapter
+# line settings: 115200 raw
+# FIXME: the adafruit-based tags show up as /dev/ttyACM, not /dev/ttyUSB
+LABEL="CornellTagXCVR"
+ACTION!="add",GOTO="done"
+IMPORT{program}="/bin/sh -c '(sleep 2; /bin/stty -F /dev/ttyUSB%n 115200 raw &)'"
+IMPORT{program}="/opt/sensorgnome/udev-usb/get-usb-port.py %p"
+ENV{PORT_NUM}!="",SYMLINK+="sensorgnome/CornellTagXCVR.port=%E{PORT_NUM}.usbPath=%s{busnum}:%s{devnum}.port_path=%E{PORT_PATH}"
+ENV{PORT_NUM}!="",RUN{program}+="/usr/bin/logger -t sensorgnome Added CornellTagXCVR %E{PORT_PATH}->port %E{PORT_NUM}"
+GOTO="done"
+
+# DigiBabel UHF FSK Tag Receiver
+# line settings: 230400 baud, 8N1, no flow control
+LABEL="DigiBabel"
+ACTION!="add",GOTO="done"
+IMPORT{program}="/bin/sh -c '(sleep 2; /bin/stty -F /dev/ttyUSB%n 230400 raw -ixon -ixoff -crtscts &)'"
+IMPORT{program}="/opt/sensorgnome/udev-usb/get-usb-port.py %p"
+ENV{PORT_NUM}!="",SYMLINK+="sensorgnome/DigiBabel.port=%E{PORT_NUM}.usbPath=%s{busnum}:%s{devnum}.port_path=%E{PORT_PATH}"
+ENV{PORT_NUM}!="",RUN{program}+="/usr/bin/logger -t sensorgnome Added DigiBabel %E{PORT_PATH}->port %E{PORT_NUM}"
+GOTO="done"
+
+# pl2303gps serial port: add a link indicating which port the device is in
+LABEL="pl2303gps"
+ACTION!="add",GOTO="done"
+# because the device node hasn't been set up yet, we need to run the
+IMPORT{program}="/opt/sensorgnome/udev-usb/get-usb-port.py %p"
+ENV{PORT_NUM}!="",SYMLINK+="sensorgnome/gps.port=%E{PORT_NUM}.pps=0.port_path=%E{PORT_PATH}"
+ENV{PORT_NUM}!="",RUN{program}+="/usr/bin/logger -t sensorgnome Added GPS %E{PORT_PATH}->port %E{PORT_NUM}"
+GOTO="done"
+
+# sensorgnome PPSGPS: a US Globalsat MR350P serial GPS interfaced via an FTDI EVAL232R board,
+# with PPS signal going directly to GPIO pin 48 (= pin 15 on jumper P9)
+LABEL="sg_ppsgps"
+ACTION!="add",GOTO="done"
+IMPORT{program}="/sbin/modprobe ftdi_sio product=0x0001 vendor=0xbd09"
+# FIXME: we'd like to use /dev/ttyUSB%n in the following, but %n won't be defined since it is
+# not until after modprobe ftdi_sio that the kernel even knows this is a serial device!
+IMPORT{program}="/bin/stty -F /dev/ttyUSB0 4800"
+IMPORT{program}="/opt/sensorgnome/udev-usb/get-usb-port.py %p"
+
+ACTION!="add",GOTO="done"
+ENV{PORT_NUM}!="",SYMLINK+="sensorgnome/gps.port=%E{PORT_NUM}.pps=1.port_path=%E{PORT_PATH}"
+ENV{PORT_NUM}!="",RUN{program}+="/usr/bin/logger -t sensorgnome Added GPS %E{PORT_PATH}->port %E{PORT_NUM}"
+GOTO="done"
+
+# any usb audio device
+LABEL="usbaudio"
+ACTION!="add",GOTO="done"
+DRIVERS=="usb",KERNEL=="controlC[0-9]",IMPORT{program}="/opt/sensorgnome/udev-usb/get-usb-port.py %p"
+DRIVERS=="usb",KERNEL=="controlC[0-9]",SYMLINK+="sensorgnome/%E{MYDEVNAME}.port=%E{PORT_NUM}.alsaDev=%n.usbPath=%s{busnum}:%s{devnum}.port_path=%E{PORT_PATH}"
+DRIVERS=="usb",KERNEL=="controlC[0-9]",RUN{program}+="/usr/bin/logger -t sensorgnome Added %E{MYDEVNAME} %E{PORT_PATH}->port %E{PORT_NUM}"
+GOTO="done"
+
+################# END OTHER DEVICE DETECTION #################
+LABEL="rtlsdr"
+################# START RTLSDR DETECTION #################
+# original RTL2832U vid/pid (hama nano, for example)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0bda", ATTRS{idProduct}=="2832",GOTO="add_rtlsdr"
+
+# RTL2832U OEM vid/pid, e.g. ezcap EzTV668 (E4000), Newsky TV28T (E4000/R820T) etc
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0bda", ATTRS{idProduct}=="2838",GOTO="add_rtlsdr"
+
+# DigitalNow Quad DVB-T PCI-E card (4x FC0012?)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0413", ATTRS{idProduct}=="6680",GOTO="add_rtlsdr"
+
+# Leadtek WinFast DTV Dongle mini D (FC0012)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0413", ATTRS{idProduct}=="6f0f",GOTO="add_rtlsdr"
+
+# Genius TVGo DVB-T03 USB dongle (Ver. B)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0458", ATTRS{idProduct}=="707f",GOTO="add_rtlsdr"
+
+# Terratec Cinergy T Stick Black (rev 1) (FC0012)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0ccd", ATTRS{idProduct}=="00a9",GOTO="add_rtlsdr"
+
+# Terratec NOXON rev 1 (FC0013)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0ccd", ATTRS{idProduct}=="00b3",GOTO="add_rtlsdr"
+
+# Terratec Deutschlandradio DAB Stick (FC0013)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0ccd", ATTRS{idProduct}=="00b4",GOTO="add_rtlsdr"
+
+# Terratec NOXON DAB Stick - Radio Energy (FC0013)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0ccd", ATTRS{idProduct}=="00b5",GOTO="add_rtlsdr"
+
+# Terratec Media Broadcast DAB Stick (FC0013)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0ccd", ATTRS{idProduct}=="00b7",GOTO="add_rtlsdr"
+
+# Terratec BR DAB Stick (FC0013)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0ccd", ATTRS{idProduct}=="00b8",GOTO="add_rtlsdr"
+
+# Terratec WDR DAB Stick (FC0013)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0ccd", ATTRS{idProduct}=="00b9",GOTO="add_rtlsdr"
+
+# Terratec MuellerVerlag DAB Stick (FC0013)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0ccd", ATTRS{idProduct}=="00c0",GOTO="add_rtlsdr"
+
+# Terratec Fraunhofer DAB Stick (FC0013)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0ccd", ATTRS{idProduct}=="00c6",GOTO="add_rtlsdr"
+
+# Terratec Cinergy T Stick RC (Rev.3) (E4000)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0ccd", ATTRS{idProduct}=="00d3",GOTO="add_rtlsdr"
+
+# Terratec T Stick PLUS (E4000)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0ccd", ATTRS{idProduct}=="00d7",GOTO="add_rtlsdr"
+
+# Terratec NOXON rev 2 (E4000)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0ccd", ATTRS{idProduct}=="00e0",GOTO="add_rtlsdr"
+
+# PixelView PV-DT235U(RN) (FC0012)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1554", ATTRS{idProduct}=="5020",GOTO="add_rtlsdr"
+
+# Astrometa DVB-T/DVB-T2 (R828D)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="15f4", ATTRS{idProduct}=="0131",GOTO="add_rtlsdr"
+
+# HanfTek DAB+FM+DVB-T
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="15f4", ATTRS{idProduct}=="0133",GOTO="add_rtlsdr"
+
+# Compro Videomate U620F (E4000)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="185b", ATTRS{idProduct}=="0620",GOTO="add_rtlsdr"
+
+# Compro Videomate U650F (E4000)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="185b", ATTRS{idProduct}=="0650",GOTO="add_rtlsdr"
+
+# Compro Videomate U680F (E4000)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="185b", ATTRS{idProduct}=="0680",GOTO="add_rtlsdr"
+
+# GIGABYTE GT-U7300 (FC0012)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b80", ATTRS{idProduct}=="d393",GOTO="add_rtlsdr"
+
+# DIKOM USB-DVBT HD
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b80", ATTRS{idProduct}=="d394",GOTO="add_rtlsdr"
+
+# Peak 102569AGPK (FC0012)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b80", ATTRS{idProduct}=="d395",GOTO="add_rtlsdr"
+
+# KWorld KW-UB450-T USB DVB-T Pico TV (TUA9001)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b80", ATTRS{idProduct}=="d397",GOTO="add_rtlsdr"
+
+# Zaapa ZT-MINDVBZP (FC0012)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b80", ATTRS{idProduct}=="d398",GOTO="add_rtlsdr"
+
+# SVEON STV20 DVB-T USB & FM (FC0012)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b80", ATTRS{idProduct}=="d39d",GOTO="add_rtlsdr"
+
+# Twintech UT-40 (FC0013)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b80", ATTRS{idProduct}=="d3a4",GOTO="add_rtlsdr"
+
+# ASUS U3100MINI_PLUS_V2 (FC0013)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b80", ATTRS{idProduct}=="d3a8",GOTO="add_rtlsdr"
+
+# SVEON STV27 DVB-T USB & FM (FC0013)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b80", ATTRS{idProduct}=="d3af",GOTO="add_rtlsdr"
+
+# SVEON STV21 DVB-T USB & FM
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b80", ATTRS{idProduct}=="d3b0",GOTO="add_rtlsdr"
+
+# Dexatek DK DVB-T Dongle (Logilink VG0002A) (FC2580)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d19", ATTRS{idProduct}=="1101",GOTO="add_rtlsdr"
+
+# Dexatek DK DVB-T Dongle (MSI DigiVox mini II V3.0)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d19", ATTRS{idProduct}=="1102",GOTO="add_rtlsdr"
+
+# Dexatek DK 5217 DVB-T Dongle (FC2580)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d19", ATTRS{idProduct}=="1103",GOTO="add_rtlsdr"
+
+# MSI DigiVox Micro HD (FC2580)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d19", ATTRS{idProduct}=="1104",GOTO="add_rtlsdr"
+
+# Sweex DVB-T USB (FC0012)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1f4d", ATTRS{idProduct}=="a803",GOTO="add_rtlsdr"
+
+# GTek T803 (FC0012)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1f4d", ATTRS{idProduct}=="b803",GOTO="add_rtlsdr"
+
+# Lifeview LV5TDeluxe (FC0012)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1f4d", ATTRS{idProduct}=="c803",GOTO="add_rtlsdr"
+
+# MyGica TD312 (FC0012)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1f4d", ATTRS{idProduct}=="d286",GOTO="add_rtlsdr"
+
+# PROlectrix DV107669 (FC0012)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1f4d", ATTRS{idProduct}=="d803",GOTO="add_rtlsdr"
+
+GOTO="done"
+
+LABEL="add_rtlsdr"
+RUN{program}+="/usr/bin/logger -t sensorgnome DBG RTLSDR"
+# Can't just use 'add' action, symlink gets removed due to subseq bind, but there's no bind
+# at boot time on a fast rpi4, so need both !?
+ACTION=="add",GOTO="rtlsdr2"
+ACTION=="bind",GOTO="rtlsdr2"
+GOTO="done"
+
+LABEL="rtlsdr2"
+RUN{program}+="/usr/bin/logger -t sensorgnome DBG add/bind RTLSDR %p %k %s{idVendor}:%s{idProduct}"
+IMPORT{program}="/opt/sensorgnome/udev-usb/get-usb-port.py %p"
+ENV{PORT_NUM}!="",SYMLINK+="sensorgnome/rtlsdr.port=%E{PORT_NUM}.usbPath=%s{busnum}:%s{devnum}.port_path=%E{PORT_PATH}.vidpid=%s{idVendor}:%s{idProduct}.mfg=%s{manufacturer}.prod=%s{product}"
+ENV{PORT_NUM}!="",RUN{program}+="/usr/bin/logger -t sensorgnome Added rtlsdr %E{PORT_PATH}->port %E{PORT_NUM}"
+GOTO="done"
+
+
+LABEL="done"
+
+# Exit

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -499,7 +499,7 @@ class Dashboard {
                 this.tsShow('lotek-snr')
                 this.tsShow('lotek-rate')
             } else {
-                this.tsGotTag(`T${port},${now/1000},12345678,0`)
+                this.tsGotTag(`T${port},${now/1000},12345678,0,1`)
                 this.tsShow('ctt-tags')
             }
         }

--- a/src/digibabel.js
+++ b/src/digibabel.js
@@ -59,6 +59,10 @@ const LED_OFF_CODE = 0x00 // Message code
 const LED_OFF_CMD = 0x0D // Command code
 const LED_OFF_OP = 0x00 // Operation code
 const LED_OFF_PL = 0x0001 // Payload length
+const CMD_REQ_PAYLOAD = 0x01
+const DET_ON_ACK_PAYLOAD = 0xFE
+const LED_OFF_ACK_PAYLOAD = 0xFF
+const CMD_ACK_TIMEOUT_MS = 2000
 
 // CRC-16-CCITT (False) implementation
 // Polynomial: 0x1021, init varies, RefIn/RefOut: False, XorOut: 0x0000
@@ -69,6 +73,7 @@ const POLY16 = 0x1021
 const POLY8 = 0x07
 
 function calcIncrCrc16(bNext, uInit) {
+  // Incrementally update CRC16 with a single next byte.
   let uCrc = uInit & 0xFFFF
   let uTemp = (bNext & 0xFF) << 8
   uCrc ^= uTemp
@@ -83,6 +88,7 @@ function calcIncrCrc16(bNext, uInit) {
 }
 
 function calcCrc16(data, offset, uInit) {
+  // Compute CRC16 over a byte buffer from offset to end.
   let uCrc = uInit & 0xFFFF
   for (let i = offset; i < data.length; i++) {
     uCrc = calcIncrCrc16(data[i], uCrc)
@@ -94,6 +100,7 @@ function calcCrc16(data, offset, uInit) {
 }
 
 function calcCrc8(data, offset, initValue) {
+  // Compute CRC8 over a byte buffer from offset to end.
   let crc = (initValue ?? 0x00) & 0xFF
   for (let i = offset ?? 0; i < data.length; i++) {
     crc ^= data[i] & 0xFF
@@ -109,6 +116,7 @@ function calcCrc8(data, offset, initValue) {
 }
 
 function hamming74ErrorCorrection(codeword) {
+  // Correct a single-bit error in a Hamming(7,4) codeword and report whether correction was applied.
   // Hamming(7,4): use only the lower 7 bits of each received byte.
   const b = codeword & 0x7F
   const bits = new Array(7)
@@ -146,6 +154,7 @@ function crcInitFromPayloadLength(length) {
 }
 
 function buildFrame(messageCode, commandCode, operationCode, payload) {
+  // Build a complete framed DigiBabel command with CRC and delimiters.
   const N = payload.length
   if (N > 255) {
     throw new Error('Payload length must be <= 255')
@@ -164,6 +173,7 @@ function buildFrame(messageCode, commandCode, operationCode, payload) {
 }
 
 class DigiBabel {
+  // Initialize a receiver instance and open its serial stream immediately.
   constructor(matron, dev, options) {
     if (!didEnum) this.enum()
 
@@ -175,6 +185,7 @@ class DigiBabel {
     this.buffer = Buffer.alloc(0) // buffer for incoming data
     this.retries = 0 // number of retries opening the device
     this.initialized = false // whether init messages have been sent
+    this.pendingControlAck = null // pending control-command acknowledgement waiter
 
     this.matron.on("devRemoved", (dev) => this.devRemoved(dev))
 
@@ -182,10 +193,12 @@ class DigiBabel {
   }
 
   getPort() {
+    // Resolve current USB port number safely for logs/state updates.
     return this.dev?.attr?.port ?? '?'
   }
 
   getPath() {
+    // Resolve current device path safely for logs after unplug events.
     return this.dev?.path ?? '<removed>'
   }
 
@@ -200,6 +213,7 @@ class DigiBabel {
   }
 
   close() {
+    // Close and detach the serial stream for this receiver instance.
     if (this.sp) {
       if (this.sp.isOpen) this.sp.close()
       this.sp = null
@@ -208,12 +222,14 @@ class DigiBabel {
   }
 
   devRemoved(dev) {
+    // React only to removal of this specific device and clear local handle.
     if (!this.dev || dev.path != this.dev.path) return
     this.close()
     this.dev = null
   }
 
   init_sp() {
+    // Open the serial device and install event handlers for lifecycle and frame input.
     if (!this.dev) return // device removed
     this.matron.emit("devState", this.dev.attr.port, "init")
     const path = this.dev.path
@@ -265,7 +281,98 @@ class DigiBabel {
     console.log("Starting DigiBabel read stream using SerialPort at", path)
   }
 
+  sendControlFrame(messageCode, commandCode, operationCode, payloadByte, expectedAckPayload, label) {
+    // Send one control command and resolve only after a matching protocol-level acknowledgement arrives.
+    if (!this.dev || !this.sp || !this.sp.isOpen) {
+      return Promise.reject(new Error(`Cannot send ${label}: serial port not open`))
+    }
+
+    if (this.pendingControlAck) {
+      return Promise.reject(new Error(`Cannot send ${label}: another control acknowledgement is pending`))
+    }
+
+    const data = buildFrame(messageCode, commandCode, operationCode, Buffer.from([payloadByte]))
+    if (this.debugRawHex) {
+      const port = this.getPort()
+      const ts = (Date.now() / 1000).toFixed(3)
+      console.log(`DigiBabel raw tx port ${port} ts=${ts} len=${data.length} hex=${data.toString('hex')}`)
+    }
+
+    return new Promise((resolve, reject) => {
+      // Start an acknowledgement timeout so init cannot hang indefinitely.
+      const timeout = setTimeout(() => {
+        if (this.pendingControlAck?.label !== label) return
+        this.pendingControlAck = null
+        reject(new Error(`Timed out waiting for ${label} acknowledgement`))
+      }, CMD_ACK_TIMEOUT_MS)
+
+      // Track the expected response shape to match in parseFrame().
+      this.pendingControlAck = {
+        label,
+        messageCode,
+        commandCode,
+        operationCode,
+        expectedAckPayload,
+        resolve,
+        reject,
+        timeout,
+      }
+
+      // Write request frame to the serial port; acknowledgement is handled asynchronously from input frames.
+      this.sp.write(data, (err) => {
+        if (!this.dev) {
+          if (this.pendingControlAck?.label === label) {
+            clearTimeout(timeout)
+            this.pendingControlAck = null
+          }
+          reject(new Error(`Cannot complete ${label}: device removed`))
+          return
+        }
+
+        if (err) {
+          if (this.pendingControlAck?.label === label) {
+            clearTimeout(timeout)
+            this.pendingControlAck = null
+          }
+          console.log(`Error writing ${label} message to ${this.getPath()}: ${err}`)
+          reject(err)
+          return
+        }
+
+        console.log(`Sent DigiBabel ${label} message to port ${this.getPort()}, waiting for ack`)
+      })
+    })
+  }
+
+  handleControlAck(frameMessageCode, frameCommandCode, frameOperationCode, payload) {
+    // Match an incoming non-tag response against the currently pending command acknowledgement.
+    const pending = this.pendingControlAck
+    if (!pending) return false
+
+    if (frameMessageCode !== pending.messageCode ||
+        frameCommandCode !== pending.commandCode ||
+        frameOperationCode !== pending.operationCode) {
+      return false
+    }
+
+    clearTimeout(pending.timeout)
+    this.pendingControlAck = null
+
+    if (payload.length === 1 && payload[0] === pending.expectedAckPayload) {
+      console.log(`Received DigiBabel ack for ${pending.label} on port ${this.getPort()}`)
+      pending.resolve()
+    } else {
+      const payloadHex = payload.toString('hex')
+      const expectedHex = pending.expectedAckPayload.toString(16).padStart(2, '0')
+      const err = new Error(`Unexpected ack payload for ${pending.label}: ${payloadHex} (expected ${expectedHex})`)
+      console.log(err.message)
+      pending.reject(err)
+    }
+    return true
+  }
+
   sendInitMessages() {
+    // Run startup command sequence and transition device state to running only after both ACKs succeed.
     if (!this.sp || !this.sp.isOpen) return
     
     try {
@@ -274,47 +381,23 @@ class DigiBabel {
       // 2) Enable detection forwarding
       setTimeout(() => {
         if (!this.dev || !this.sp || !this.sp.isOpen) return
+        ;(async () => {
+          try {
+            // Keep startup ordering explicit: LED behavior first, then detection forwarding.
+            await this.sendControlFrame(LED_OFF_CODE, LED_OFF_CMD, LED_OFF_OP, CMD_REQ_PAYLOAD, LED_OFF_ACK_PAYLOAD, 'LED disable')
+            await this.sendControlFrame(DET_ON_CODE, DET_ON_CMD, DET_ON_OP, CMD_REQ_PAYLOAD, DET_ON_ACK_PAYLOAD, 'detection forwarding enable')
 
-        const sendDetectionForwarding = () => {
-          if (!this.dev || !this.sp || !this.sp.isOpen) return
-
-          const detOnData = buildFrame(DET_ON_CODE, DET_ON_CMD, DET_ON_OP, Buffer.from([DET_ON_PL]))
-          if (this.debugRawHex) {
-            const port = this.getPort()
-            const ts = (Date.now() / 1000).toFixed(3)
-            console.log(`DigiBabel raw tx port ${port} ts=${ts} len=${detOnData.length} hex=${detOnData.toString('hex')}`)
-          }
-
-          this.sp.write(detOnData, (detErr) => {
             if (!this.dev) return
-
-            if (detErr) {
-              console.log(`Error writing detection forwarding message to ${this.getPath()}: ${detErr}`)
-            } else {
-              const port = this.getPort()
-              console.log(`Sent DigiBabel detection forwarding message to port ${port}`)
-              this.initialized = true
-              this.matron.emit("devState", port, "running")
-            }
-          })
-        }
-
-        const ledOffData = buildFrame(LED_OFF_CODE, LED_OFF_CMD, LED_OFF_OP, Buffer.from([LED_OFF_PL]))
-        if (this.debugRawHex) {
-          const port = this.getPort()
-          const ts = (Date.now() / 1000).toFixed(3)
-          console.log(`DigiBabel raw tx port ${port} ts=${ts} len=${ledOffData.length} hex=${ledOffData.toString('hex')}`)
-        }
-        this.sp.write(ledOffData, (err) => {
-          if (!this.dev) return
-
-          if (err) {
-            console.log(`Error writing LED disable message to ${this.getPath()}: ${err}`)
-          } else {
-            console.log(`Sent DigiBabel LED disable message to port ${this.getPort()}`)
+            const port = this.getPort()
+            this.initialized = true
+            this.matron.emit("devState", port, "running")
+          } catch (initErr) {
+            if (!this.dev || this.dev.state?.startsWith("err")) return
+            const msg = `DigiBabel init failed: ${initErr.message}`
+            console.log(msg)
+            this.matron.emit("devState", this.getPort(), "error", msg)
           }
-          sendDetectionForwarding()
-        })
+        })()
       }, 100)
     } catch (err) {
       console.log(`Error building init messages: ${err.message}`)
@@ -322,6 +405,7 @@ class DigiBabel {
   }
 
   processBuffer() {
+    // Incrementally parse framed protocol data from a rolling serial buffer.
     while (true) {
       // Look for start flag
       const startIdx = this.buffer.indexOf(START_FLAG)
@@ -366,6 +450,7 @@ class DigiBabel {
   }
 
   parseFrame(frame, length, messageCode, commandCode, operationCode) {
+    // Validate one complete frame and dispatch either ACK responses or tag detections.
     const port = this.getPort()
 
     // Validate stop flag
@@ -394,6 +479,11 @@ class DigiBabel {
       }
       return false
     }
+
+    // Resolve any in-flight control-command acknowledgement before generic handling.
+    if (this.handleControlAck(messageCode, commandCode, operationCode, payload)) {
+      return true
+    }
     
     // Process based on command code
     if (commandCode === TAG_DETECTION_CMD) {
@@ -410,6 +500,7 @@ class DigiBabel {
   }
 
   handleTagDetection(payload) {
+    // Decode a tag-detection payload, validate/correct ID bits, and emit the normalized gotTag record.
     if (!this.dev) return
     const port = this.getPort()
 

--- a/src/digibabel.js
+++ b/src/digibabel.js
@@ -28,11 +28,14 @@
 //       - Byte 4: RSSI (raw 0-255 value)
 //
 //   This module watches for such frames, and emits gotTag events of the form:
-//       T[0-9]{1,2},<TS>,<ID>,<valid>,<RSSI>\n
+//       T[0-9]{1,2},<TS>,<ID>,<RSSI>,<valid>\n
 //   where the number after 'T' is the USB port #, <TS> is the timestamp in seconds,
-//   <ID> is the 8-hex digit tag ID.  <valid> is 1 when the embedded CRC matches
-//   a CRC-8 over the tag ID bytes (width=8, poly=0x07, init=0x00) and 0 otherwise.
-//   <RSSI> is the RSSI value in dB.
+//   <ID> is the 8-hex digit tag ID. <RSSI> is the RSSI value in dB.
+//   <valid> is:
+//     1 when the embedded CRC matches a CRC-8 over the tag ID bytes
+//       (width=8, poly=0x07, init=0x00),
+//     0 when the embedded CRC does not match (new 6-byte schema),
+//    -1 for old 5-byte schema detections that carry no embedded CRC.
 
 const {SerialPort} = require('serialport')
 
@@ -46,10 +49,16 @@ const DEBUG_RAW_HEX = false
 const START_FLAG = 0x3C  // '<'
 const STOP_FLAG = 0x3E   // '>'
 const TAG_DETECTION_CMD = 0x82
-const INIT_CODE = 0x00
-const INIT_CMD = 0x0C
-const INIT_OP = 0x00
-const INIT_PL = 0x01
+// Bytes to enable detection forwarding from the digibabel
+const DET_ON_CODE = 0x00 // Message code
+const DET_ON_CMD = 0x0C // Command code
+const DET_ON_OP = 0x00 // Operation code
+const DET_ON_PL = 0x0001 // Payload length
+// Bytes to disable LED blinking during detections (Lotek notes that LED blinking can reduce the max detection rate)
+const LED_OFF_CODE = 0x00 // Message code
+const LED_OFF_CMD = 0x0D // Command code
+const LED_OFF_OP = 0x00 // Operation code
+const LED_OFF_PL = 0x0001 // Payload length
 
 // CRC-16-CCITT (False) implementation
 // Polynomial: 0x1021, init varies, RefIn/RefOut: False, XorOut: 0x0000
@@ -99,6 +108,38 @@ function calcCrc8(data, offset, initValue) {
   return crc & 0xFF
 }
 
+function hamming74ErrorCorrection(codeword) {
+  // Hamming(7,4): use only the lower 7 bits of each received byte.
+  const b = codeword & 0x7F
+  const bits = new Array(7)
+  for (let i = 0; i < 7; i++) {
+    bits[i] = (b >> i) & 0x01
+  }
+
+  // Syndrome bits from parity-check rows:
+  // s0: [1,0,1,0,1,0,1], s1: [0,1,1,0,0,1,1], s2: [0,0,0,1,1,1,1]
+  const s0 = (bits[0] ^ bits[2] ^ bits[4] ^ bits[6]) & 0x01
+  const s1 = (bits[1] ^ bits[2] ^ bits[5] ^ bits[6]) & 0x01
+  const s2 = (bits[3] ^ bits[4] ^ bits[5] ^ bits[6]) & 0x01
+  const syndrome = (s2 << 2) | (s1 << 1) | s0
+
+  let corrected = false
+  if (syndrome !== 0) {
+    const errorPos = syndrome - 1
+    if (errorPos < 7) {
+      bits[errorPos] ^= 0x01
+      corrected = true
+    }
+  }
+
+  let correctedCodeword = 0
+  for (let i = 0; i < 7; i++) {
+    correctedCodeword |= (bits[i] & 0x01) << i
+  }
+
+  return { correctedCodeword: correctedCodeword & 0x7F, corrected }
+}
+
 function crcInitFromPayloadLength(length) {
   // The USB CRC init depends on the payload length in this way: 0x{length}00.
   return ((length & 0xFF) << 8) & 0xFFFF
@@ -140,6 +181,14 @@ class DigiBabel {
     this.init_sp()
   }
 
+  getPort() {
+    return this.dev?.attr?.port ?? '?'
+  }
+
+  getPath() {
+    return this.dev?.path ?? '<removed>'
+  }
+
   // enumerate serial ports for debugging purposes
   enum() {
     didEnum = true
@@ -154,7 +203,7 @@ class DigiBabel {
     if (this.sp) {
       if (this.sp.isOpen) this.sp.close()
       this.sp = null
-      console.log("Removed " + this.dev.path)
+      console.log("Removed " + this.getPath())
     }
   }
 
@@ -220,22 +269,51 @@ class DigiBabel {
     if (!this.sp || !this.sp.isOpen) return
     
     try {
-      // Send initialization message: command 0x0C, operation 0x00, payload 0x01
+      // Send initialization messages in order:
+      // 1) Disable LED blinking
+      // 2) Enable detection forwarding
       setTimeout(() => {
-        const data = buildFrame(INIT_CODE, INIT_CMD, INIT_OP, Buffer.from([INIT_PL]))
-        if (this.debugRawHex) {
-          const port = this.dev?.attr?.port ?? '?'
-          const ts = (Date.now() / 1000).toFixed(3)
-          console.log(`DigiBabel raw tx port ${port} ts=${ts} len=${data.length} hex=${data.toString('hex')}`)
-        }
-        this.sp.write(data, (err) => {
-          if (err) {
-            console.log(`Error writing init message to ${this.dev?.path}: ${err}`)
-          } else {
-            console.log(`Sent DigiBabel init message to port ${this.dev.attr.port}`)
-            this.initialized = true
-            this.matron.emit("devState", this.dev.attr.port, "running")
+        if (!this.dev || !this.sp || !this.sp.isOpen) return
+
+        const sendDetectionForwarding = () => {
+          if (!this.dev || !this.sp || !this.sp.isOpen) return
+
+          const detOnData = buildFrame(DET_ON_CODE, DET_ON_CMD, DET_ON_OP, Buffer.from([DET_ON_PL]))
+          if (this.debugRawHex) {
+            const port = this.getPort()
+            const ts = (Date.now() / 1000).toFixed(3)
+            console.log(`DigiBabel raw tx port ${port} ts=${ts} len=${detOnData.length} hex=${detOnData.toString('hex')}`)
           }
+
+          this.sp.write(detOnData, (detErr) => {
+            if (!this.dev) return
+
+            if (detErr) {
+              console.log(`Error writing detection forwarding message to ${this.getPath()}: ${detErr}`)
+            } else {
+              const port = this.getPort()
+              console.log(`Sent DigiBabel detection forwarding message to port ${port}`)
+              this.initialized = true
+              this.matron.emit("devState", port, "running")
+            }
+          })
+        }
+
+        const ledOffData = buildFrame(LED_OFF_CODE, LED_OFF_CMD, LED_OFF_OP, Buffer.from([LED_OFF_PL]))
+        if (this.debugRawHex) {
+          const port = this.getPort()
+          const ts = (Date.now() / 1000).toFixed(3)
+          console.log(`DigiBabel raw tx port ${port} ts=${ts} len=${ledOffData.length} hex=${ledOffData.toString('hex')}`)
+        }
+        this.sp.write(ledOffData, (err) => {
+          if (!this.dev) return
+
+          if (err) {
+            console.log(`Error writing LED disable message to ${this.getPath()}: ${err}`)
+          } else {
+            console.log(`Sent DigiBabel LED disable message to port ${this.getPort()}`)
+          }
+          sendDetectionForwarding()
         })
       }, 100)
     } catch (err) {
@@ -280,18 +358,20 @@ class DigiBabel {
       
       // Extract the complete frame
       const frame = this.buffer.slice(0, frameLength)
-      this.buffer = this.buffer.slice(frameLength)
-      
-      // Parse the frame
-      this.parseFrame(frame, length, messageCode, commandCode, operationCode)
+
+      // Parse frame before consuming it; on invalid frame, advance only one byte to resync.
+      const ok = this.parseFrame(frame, length, messageCode, commandCode, operationCode)
+      this.buffer = this.buffer.slice(ok ? frameLength : 1)
     }
   }
 
   parseFrame(frame, length, messageCode, commandCode, operationCode) {
+    const port = this.getPort()
+
     // Validate stop flag
     if (frame[frame.length - 1] !== STOP_FLAG) {
-      console.log(`Invalid stop flag in DigiBabel frame on port ${this.dev.attr.port}`)
-      return
+      console.log(`Invalid stop flag in DigiBabel frame on port ${port}; attempting resync`)
+      return false
     }
     
     // Extract payload and CRC
@@ -304,9 +384,15 @@ class DigiBabel {
     const crcComputed = calcCrc16(core, 0, crcInitFromPayloadLength(length))
     
     if (crcReceived !== crcComputed) {
-      console.log(`CRC mismatch in DigiBabel frame on port ${this.dev.attr.port}: ` +
-                  `received 0x${crcReceived.toString(16)}, computed 0x${crcComputed.toString(16)}, core=${core.toString('hex')}`)
-      return
+      if (commandCode === TAG_DETECTION_CMD) {
+        // USB-level CRC failed, so this detection is ignored and never emitted as gotTag.
+        console.log(`Discarded DigiBabel detection on port ${port} due to USB CRC mismatch: ` +
+                    `received 0x${crcReceived.toString(16)}, computed 0x${crcComputed.toString(16)}, core=${core.toString('hex')}`)
+      } else {
+        console.log(`CRC mismatch in DigiBabel frame on port ${port}: ` +
+                    `received 0x${crcReceived.toString(16)}, computed 0x${crcComputed.toString(16)}, core=${core.toString('hex')}`)
+      }
+      return false
     }
     
     // Process based on command code
@@ -314,22 +400,28 @@ class DigiBabel {
       this.handleTagDetection(payload)
     } else {
       // Other command responses (could be init responses, status, etc.)
-      console.log(`DigiBabel response on port ${this.dev.attr.port}: ` +
+      console.log(`DigiBabel response on port ${port}: ` +
                   `cmd=0x${commandCode.toString(16).padStart(2, '0')}, ` +
                   `op=0x${operationCode.toString(16).padStart(2, '0')}, ` +
                   `payload=${payload.toString('hex')}`)
     }
+
+    return true
   }
 
   handleTagDetection(payload) {
+    if (!this.dev) return
+    const port = this.getPort()
+
     // Old payload is 5 bytes; new payload is 6 bytes.
     if (payload.length < 5) {
-      console.log(`Invalid tag detection payload length on port ${this.dev.attr.port}: ${payload.length}`)
+      console.log(`Invalid tag detection payload length on port ${port}: ${payload.length}`)
       return
     }
     
-    // Extract tag ID (bytes 0-3)
-    const tagId = payload.slice(0, 4).toString('hex')
+    // Extract original Tag ID bytes (bytes 0-3).
+    const tagOnlyOriginal = Buffer.from(payload.slice(0, 4))
+    let tagOnlyForRecord = tagOnlyOriginal
 
     // New schema includes an embedded CRC byte at payload[4] and moves RSSI to payload[5].
     // Old schema has RSSI at payload[4] and provides no embedded CRC.
@@ -338,22 +430,45 @@ class DigiBabel {
     if (payload.length >= 6) {
       const embeddedCrcReceived = payload[4] & 0xFF
 
-      // The embedded CRC is a CRC-8 over the TagID bytes (payload[0..3]).
-      const tagOnly = payload.slice(0, 4)
-      const embeddedCrcComputed8 = calcCrc8(tagOnly, 0, 0x00)
+      // Apply Hamming(7,4) correction to each Tag ID byte before CRC validation.
+      const tagOnlyCorrected = Buffer.from(tagOnlyOriginal)
+      const hammingCorrections = []
+      for (let i = 0; i < 4; i++) {
+        const originalByte = tagOnlyOriginal[i]
+        const { correctedCodeword, corrected } = hamming74ErrorCorrection(originalByte)
+        tagOnlyCorrected[i] = correctedCodeword
+        if (corrected) {
+          hammingCorrections.push(`byte[${i}] 0x${originalByte.toString(16).padStart(2, '0')}->0x${correctedCodeword.toString(16).padStart(2, '0')}`)
+        }
+      }
+      if (hammingCorrections.length > 0) {
+        console.log(`DigiBabel Hamming correction on port ${port}: ${hammingCorrections.join(', ')}`)
+      }
+
+      // The embedded CRC is a CRC-8 over the corrected TagID bytes.
+      const embeddedCrcComputed8 = calcCrc8(tagOnlyCorrected, 0, 0x00)
       valid = (embeddedCrcReceived === embeddedCrcComputed8) ? 1 : 0
+
+      // If corrected Tag ID fails CRC, keep the originally received Tag ID in output.
+      if (valid === 1) {
+        tagOnlyForRecord = tagOnlyCorrected
+      } else {
+        tagOnlyForRecord = tagOnlyOriginal
+      }
 
       rssiRaw = payload[5]
     } else {
       // Old schema: no embedded CRC byte.
       valid = -1
+      tagOnlyForRecord = tagOnlyOriginal
       rssiRaw = payload[4]
     }
+
+    const tagId = tagOnlyForRecord.toString('hex')
     
-    // Convert RSSI to dB: 10 * log10(rssiRaw / 255)
     let rssiDb
     if (rssiRaw > 0) {
-      rssiDb = 10 * Math.log10(rssiRaw / 255)
+      rssiDb = -rssiRaw / 2 // Formula provided by Lotek
     } else {
       rssiDb = -Infinity
     }
@@ -362,7 +477,7 @@ class DigiBabel {
     const nowSecs = Date.now() / 1000
     
     // Build the record in the expected format: T<port>,<timestamp>,<tagid>,<rssi>,<valid>
-    const lifetagRecord = `T${this.dev.attr.port},${nowSecs},${tagId},${rssiDb.toFixed(2)},${valid}`
+    const lifetagRecord = `T${port},${nowSecs},${tagId},${rssiDb.toFixed(1)},${valid}`
     
     // Emit the gotTag event
     this.matron.emit("gotTag", lifetagRecord)

--- a/src/digibabel.js
+++ b/src/digibabel.js
@@ -28,7 +28,7 @@
 //       - Byte 4: RSSI (raw 0-255 value)
 //
 //   This module watches for such frames, and emits gotTag events of the form:
-//       T[0-9]{1,2},<TS>,<ID>,<RSSI>,<valid>\n
+//       T[0-9]{1,2},<TS>,<ID>,<RSSI>,<valid>[,<extraPayloadHex>]\n
 //   where the number after 'T' is the USB port #, <TS> is the timestamp in seconds,
 //   <ID> is the 8-hex digit tag ID. <RSSI> is the RSSI value in dB.
 //   <valid> is:
@@ -39,29 +39,42 @@
 
 const {SerialPort} = require('serialport')
 
+// Guard to enumerate available serial ports only once per module load for debugging.
 let didEnum = false
+// Monotonic counter used to tag each SerialPort instance in log messages.
 let debugId = 1
 
 // Debug switch: set to true to log every raw received serial chunk as hex.
 const DEBUG_RAW_HEX = false
+const ENABLE_EXTENDED_PAYLOAD = true
 
 // Protocol constants
 const START_FLAG = 0x3C  // '<'
 const STOP_FLAG = 0x3E   // '>'
 const TAG_DETECTION_CMD = 0x82
+const CMD_MSG_CODE = 0x00 // Message code (always 0x00)
+const CMD_OP_CODE = 0x00 // Operation code (almost always 0x00)
+const CMD_PL = 0x01 // Command payload (always 0x01)
 // Bytes to enable detection forwarding from the digibabel
-const DET_ON_CODE = 0x00 // Message code
-const DET_ON_CMD = 0x0C // Command code
-const DET_ON_OP = 0x00 // Operation code
-const DET_ON_PL = 0x0001 // Payload length
+const DET_ON_CMD_CODE = 0x0C // Command code
+// Bytes to disable detection forwarding from the digibabel
+const DET_OFF_CMD_CODE = 0x0D // Command code
+// Bytes to read config from the digibabel (uses DET_ON_CMD_CODE)
+const READ_CFG_OP_CODE = 0x01 // Operation code to read config (used with DET_ON_CMD_CODE)
+const READ_CFG_PL = 0x00 // Command payload to read current config (returns current config in ACK payload)
 // Bytes to disable LED blinking during detections (Lotek notes that LED blinking can reduce the max detection rate)
-const LED_OFF_CODE = 0x00 // Message code
-const LED_OFF_CMD = 0x0D // Command code
-const LED_OFF_OP = 0x00 // Operation code
-const LED_OFF_PL = 0x0001 // Payload length
-const CMD_REQ_PAYLOAD = 0x01
-const DET_ON_ACK_PAYLOAD = 0xFE
-const LED_OFF_ACK_PAYLOAD = 0xFF
+const LED_OFF_CMD_CODE = 0x0E // Command code
+// Extended payload enabled command payload bytes
+const EXT_PL_CMD_CODE = 0x0B // Command code
+const EXT_PL_ON_PL = Buffer.from('04AAAAD391191901', 'hex')
+const EXT_PL_OFF_PL = Buffer.from('04AAAAD391191900', 'hex')
+// Expected payload bytes in the ACK responses to the above commands
+const DET_ON_ACK_PL = 0xFE
+const DET_OFF_ACK_PL = 0xFF
+const LED_OFF_ACK_PL = 0xFE
+const EXT_PL_ON_ACK_PL = EXT_PL_ON_PL
+const EXT_PL_OFF_ACK_PL = EXT_PL_OFF_PL
+// Timeout for ACK responses
 const CMD_ACK_TIMEOUT_MS = 2000
 
 // CRC-16-CCITT (False) implementation
@@ -148,11 +161,6 @@ function hamming74ErrorCorrection(codeword) {
   return { correctedCodeword: correctedCodeword & 0x7F, corrected }
 }
 
-function crcInitFromPayloadLength(length) {
-  // The USB CRC init depends on the payload length in this way: 0x{length}00.
-  return ((length & 0xFF) << 8) & 0xFFFF
-}
-
 function buildFrame(messageCode, commandCode, operationCode, payload) {
   // Build a complete framed DigiBabel command with CRC and delimiters.
   const N = payload.length
@@ -162,7 +170,7 @@ function buildFrame(messageCode, commandCode, operationCode, payload) {
   
   const head = Buffer.from([N, messageCode, commandCode, operationCode])
   const core = Buffer.concat([head, payload])
-  const crc = calcCrc16(core, 0, crcInitFromPayloadLength(N))
+  const crc = calcCrc16(core.slice(1), 0, 0)
   
   return Buffer.concat([
     Buffer.from([START_FLAG]),
@@ -170,6 +178,14 @@ function buildFrame(messageCode, commandCode, operationCode, payload) {
     Buffer.from([(crc >> 8) & 0xFF, crc & 0xFF]),
     Buffer.from([STOP_FLAG])
   ])
+}
+
+function normalizePayload(payload) {
+  // Require a Buffer so callers make payload size explicit at the call site.
+  if (Buffer.isBuffer(payload)) {
+    return payload
+  }
+  throw new Error('Payload must be a Buffer')
 }
 
 class DigiBabel {
@@ -281,8 +297,9 @@ class DigiBabel {
     console.log("Starting DigiBabel read stream using SerialPort at", path)
   }
 
-  sendControlFrame(messageCode, commandCode, operationCode, payloadByte, expectedAckPayload, label) {
-    // Send one control command and resolve only after a matching protocol-level acknowledgement arrives.
+  sendControlFrame(messageCode, commandCode, operationCode, payload, expectedAckPayload, label) {
+    // Send one control command and resolve when a matching protocol-level acknowledgement arrives.
+    // If expectedAckPayload is null/undefined, resolve with whatever payload the response carries.
     if (!this.dev || !this.sp || !this.sp.isOpen) {
       return Promise.reject(new Error(`Cannot send ${label}: serial port not open`))
     }
@@ -291,7 +308,10 @@ class DigiBabel {
       return Promise.reject(new Error(`Cannot send ${label}: another control acknowledgement is pending`))
     }
 
-    const data = buildFrame(messageCode, commandCode, operationCode, Buffer.from([payloadByte]))
+    const payloadBuffer = normalizePayload(payload)
+  const allowAnyAckPayload = expectedAckPayload == null
+  const expectedAckBuffer = allowAnyAckPayload ? null : normalizePayload(expectedAckPayload)
+    const data = buildFrame(messageCode, commandCode, operationCode, payloadBuffer)
     if (this.debugRawHex) {
       const port = this.getPort()
       const ts = (Date.now() / 1000).toFixed(3)
@@ -312,7 +332,8 @@ class DigiBabel {
         messageCode,
         commandCode,
         operationCode,
-        expectedAckPayload,
+        allowAnyAckPayload,
+        expectedAckPayload: expectedAckBuffer,
         resolve,
         reject,
         timeout,
@@ -358,12 +379,18 @@ class DigiBabel {
     clearTimeout(pending.timeout)
     this.pendingControlAck = null
 
-    if (payload.length === 1 && payload[0] === pending.expectedAckPayload) {
+    if (pending.allowAnyAckPayload) {
+      console.log(`Received DigiBabel response for ${pending.label} on port ${this.getPort()}: payload=${payload.toString('hex')}`)
+      pending.resolve(payload)
+      return true
+    }
+
+    if (payload.equals(pending.expectedAckPayload)) {
       console.log(`Received DigiBabel ack for ${pending.label} on port ${this.getPort()}`)
-      pending.resolve()
+      pending.resolve(payload)
     } else {
       const payloadHex = payload.toString('hex')
-      const expectedHex = pending.expectedAckPayload.toString(16).padStart(2, '0')
+      const expectedHex = pending.expectedAckPayload.toString('hex')
       const err = new Error(`Unexpected ack payload for ${pending.label}: ${payloadHex} (expected ${expectedHex})`)
       console.log(err.message)
       pending.reject(err)
@@ -371,37 +398,73 @@ class DigiBabel {
     return true
   }
 
+  logReadConfigPayload(configPayload) {
+    // READ_CFG response payload layout:
+    // bytes 0..3: receiver serial number, byte 4: echoed command payload, byte 5: extended payload enable status.
+    if (!Buffer.isBuffer(configPayload)) {
+      throw new Error('Invalid READ_CFG response: payload is not a Buffer')
+    }
+    if (configPayload.length !== 6) {
+      throw new Error(`Invalid READ_CFG response length ${configPayload.length}; expected 6 bytes`)
+    }
+
+    const receiverSerialHex = configPayload.slice(0, 4).toString('hex')
+    const echoedPayload = configPayload[4] & 0xFF
+    const extPayloadStatus = configPayload[5] & 0xFF
+    const extPayloadEnabled = extPayloadStatus !== 0
+
+    console.log(
+      `DigiBabel config on port ${this.getPort()}: receiverSerial=0x${receiverSerialHex}, ` +
+      `echoedPayload=0x${echoedPayload.toString(16).padStart(2, '0')}, ` +
+      `extendedPayload=${extPayloadEnabled ? 'enabled' : 'disabled'} (0x${extPayloadStatus.toString(16).padStart(2, '0')})`
+    )
+
+    if (echoedPayload !== READ_CFG_PL) {
+      console.log(
+        `Unexpected READ_CFG echoed payload on port ${this.getPort()}: ` +
+        `0x${echoedPayload.toString(16).padStart(2, '0')} (expected 0x${READ_CFG_PL.toString(16).padStart(2, '0')})`
+      )
+    }
+  }
+
   sendInitMessages() {
-    // Run startup command sequence and transition device state to running only after both ACKs succeed.
+    // Run startup command sequence and transition device state to running only after all command responses succeed.
     if (!this.sp || !this.sp.isOpen) return
     
-    try {
-      // Send initialization messages in order:
-      // 1) Disable LED blinking
-      // 2) Enable detection forwarding
-      setTimeout(() => {
-        if (!this.dev || !this.sp || !this.sp.isOpen) return
-        ;(async () => {
-          try {
-            // Keep startup ordering explicit: LED behavior first, then detection forwarding.
-            await this.sendControlFrame(LED_OFF_CODE, LED_OFF_CMD, LED_OFF_OP, CMD_REQ_PAYLOAD, LED_OFF_ACK_PAYLOAD, 'LED disable')
-            await this.sendControlFrame(DET_ON_CODE, DET_ON_CMD, DET_ON_OP, CMD_REQ_PAYLOAD, DET_ON_ACK_PAYLOAD, 'detection forwarding enable')
-
-            if (!this.dev) return
-            const port = this.getPort()
-            this.initialized = true
-            this.matron.emit("devState", port, "running")
-          } catch (initErr) {
-            if (!this.dev || this.dev.state?.startsWith("err")) return
-            const msg = `DigiBabel init failed: ${initErr.message}`
-            console.log(msg)
-            this.matron.emit("devState", this.getPort(), "error", msg)
-          }
-        })()
-      }, 100)
-    } catch (err) {
-      console.log(`Error building init messages: ${err.message}`)
-    }
+    // Send initialization messages in order:
+    // 1) Disable LED blinking
+    // 2) Enable detection forwarding
+    setTimeout(async () => {
+      if (!this.dev || !this.sp || !this.sp.isOpen) return
+      try {
+        // Disable detection forwarding first to avoid receiving detections while changing other settings.
+        await this.sendControlFrame(CMD_MSG_CODE, DET_OFF_CMD_CODE, CMD_OP_CODE, Buffer.from([CMD_PL]), Buffer.from([DET_OFF_ACK_PL]), 'detection forwarding disable')
+        // Request current DigiBabel config and print the returned payload fields.
+        const cfgPayload = await this.sendControlFrame(CMD_MSG_CODE, DET_ON_CMD_CODE, READ_CFG_OP_CODE, Buffer.from([READ_CFG_PL]), null, 'read detection settings')
+        this.logReadConfigPayload(cfgPayload)
+        // Enable or disable extended payloads based on the switch.
+        // Note: the device must be power cycled before the extended payload enable/disable command takes effect!
+        if (ENABLE_EXTENDED_PAYLOAD) {
+          await this.sendControlFrame(CMD_MSG_CODE, EXT_PL_CMD_CODE, CMD_OP_CODE, EXT_PL_ON_PL, EXT_PL_ON_ACK_PL, 'Extended payload enable')
+        } else {
+          await this.sendControlFrame(CMD_MSG_CODE, EXT_PL_CMD_CODE, CMD_OP_CODE, EXT_PL_OFF_PL, EXT_PL_OFF_ACK_PL, 'Extended payload disable')
+        }
+        // Disable LED blinking to maximize detection rate, as suggested by Lotek.
+        await this.sendControlFrame(CMD_MSG_CODE, LED_OFF_CMD_CODE, CMD_OP_CODE, Buffer.from([CMD_PL]), Buffer.from([LED_OFF_ACK_PL]), 'LED disable')
+        // Re-enable detection forwarding
+        await this.sendControlFrame(CMD_MSG_CODE, DET_ON_CMD_CODE, CMD_OP_CODE, Buffer.from([CMD_PL]), Buffer.from([DET_ON_ACK_PL]), 'detection forwarding enable')
+        
+        if (!this.dev) return
+        const port = this.getPort()
+        this.initialized = true
+        this.matron.emit("devState", port, "running")
+      } catch (initErr) {
+        if (!this.dev || this.dev.state?.startsWith("err")) return
+        const msg = `DigiBabel init failed: ${initErr.message}`
+        console.log(msg)
+        this.matron.emit("devState", this.getPort(), "error", msg)
+      }
+    }, 100)
   }
 
   processBuffer() {
@@ -464,9 +527,9 @@ class DigiBabel {
     const crcBytes = frame.slice(5 + length, 5 + length + 2)
     const crcReceived = (crcBytes[0] << 8) | crcBytes[1]
     
-    // Compute CRC over header + payload using init=0x{payloadLength}00
-    const core = frame.slice(1, 5 + length)
-    const crcComputed = calcCrc16(core, 0, crcInitFromPayloadLength(length))
+    // Compute CRC over from command code to end of payload using init=0x0000
+    const core = frame.slice(2, 5 + length)
+    const crcComputed = calcCrc16(core, 0, 0)
     
     if (crcReceived !== crcComputed) {
       if (commandCode === TAG_DETECTION_CMD) {
@@ -555,20 +618,28 @@ class DigiBabel {
       rssiRaw = payload[4]
     }
 
+    // Lotek indicates that RSSI saturation occurs around -41 dB (82 raw), and that it's
+    // possible for very weak signals < -127.5 dB (255 raw) to overflow the byte, resulting
+    // in misleading RSSI readings in the 0 to -41 dB (0-80 raw) range. So here we reassign any
+    // raw RSSI value below 80 to 255.
+    if (rssiRaw < 80) {
+      rssiRaw = 255
+    }
+
     const tagId = tagOnlyForRecord.toString('hex')
     
     let rssiDb
-    if (rssiRaw > 0) {
-      rssiDb = -rssiRaw / 2 // Formula provided by Lotek
-    } else {
-      rssiDb = -Infinity
-    }
+    rssiDb = -rssiRaw / 2 // Formula provided by Lotek
     
     // Get current timestamp in seconds
     const nowSecs = Date.now() / 1000
     
-    // Build the record in the expected format: T<port>,<timestamp>,<tagid>,<rssi>,<valid>
-    const lifetagRecord = `T${port},${nowSecs},${tagId},${rssiDb.toFixed(1)},${valid}`
+    // Build the record in the expected format: T<port>,<timestamp>,<tagid>,<rssi>,<valid>[,<extraPayloadHex>]
+    // For payloads with at least 6 bytes, add an extra column for bytes after index 5.
+    // Exactly 6-byte payloads still include the empty trailing column.
+    const extraPayloadHex = payload.length >= 6 ? payload.slice(6).toString('hex') : null
+    const lifetagRecord = `T${port},${nowSecs},${tagId},${rssiDb.toFixed(1)},${valid}` +
+                (extraPayloadHex !== null ? `,${extraPayloadHex}` : '')
     
     // Emit the gotTag event
     this.matron.emit("gotTag", lifetagRecord)

--- a/src/digibabel.js
+++ b/src/digibabel.js
@@ -16,32 +16,48 @@
 //     START_FLAG (0x3C '<') | LENGTH (1 byte) | MESSAGE_CODE | COMMAND_CODE | 
 //     OPERATION_CODE | PAYLOAD (N bytes) | CRC16 (2 bytes, MSB first) | STOP_FLAG (0x3E '>')
 //
-//   Tag detections have COMMAND_CODE = 0x82 and contain:
-//     - Bytes 0-2: Tag ID (3 bytes)
-//     - Byte 4: RSSI (raw 0-255 value)
+//   Tag detections have COMMAND_CODE = 0x82 and contain one of two payload schemas:
+//
+//     New schema (payload length 6 bytes):
+//       - Bytes 0-3: Tag ID (4 bytes)
+//       - Byte 4: Embedded CRC byte
+//       - Byte 5: RSSI (raw 0-255 value)
+//
+//     Old schema (payload length 5 bytes):
+//       - Bytes 0-3: Tag ID (4 bytes)
+//       - Byte 4: RSSI (raw 0-255 value)
 //
 //   This module watches for such frames, and emits gotTag events of the form:
-//       T[0-9]{1,2},<TS>,<ID>,<RSSI>\n
+//       T[0-9]{1,2},<TS>,<ID>,<valid>,<RSSI>\n
 //   where the number after 'T' is the USB port #, <TS> is the timestamp in seconds,
-//   <ID> is the 6-hex digit tag ID, and <RSSI> is the RSSI value in dB.
+//   <ID> is the 8-hex digit tag ID.  <valid> is 1 when the embedded CRC matches
+//   a CRC-8 over the tag ID bytes (width=8, poly=0x07, init=0x00) and 0 otherwise.
+//   <RSSI> is the RSSI value in dB.
 
 const {SerialPort} = require('serialport')
 
 let didEnum = false
 let debugId = 1
 
+// Debug switch: set to true to log every raw received serial chunk as hex.
+const DEBUG_RAW_HEX = false
+
 // Protocol constants
 const START_FLAG = 0x3C  // '<'
 const STOP_FLAG = 0x3E   // '>'
 const TAG_DETECTION_CMD = 0x82
-const INIT_CMD_1 = 0x0C
-const INIT_OP_1 = 0x01
-const INIT_CMD_2 = 0x0C
-const INIT_OP_2 = 0x00
+const INIT_CODE = 0x00
+const INIT_CMD = 0x0C
+const INIT_OP = 0x00
+const INIT_PL = 0x01
 
 // CRC-16-CCITT (False) implementation
-// Polynomial: 0x1021, Init varies, RefIn/RefOut: False, XorOut: 0x0000
-const POLY = 0x1021
+// Polynomial: 0x1021, init varies, RefIn/RefOut: False, XorOut: 0x0000
+const POLY16 = 0x1021
+
+// CRC-8 implementation
+// Polynomial: 0x07, init=0x00, refin/refout=false, xorout=0x00
+const POLY8 = 0x07
 
 function calcIncrCrc16(bNext, uInit) {
   let uCrc = uInit & 0xFFFF
@@ -49,7 +65,7 @@ function calcIncrCrc16(bNext, uInit) {
   uCrc ^= uTemp
   for (let i = 0; i < 8; i++) {
     if ((uCrc & 0x8000) !== 0) {
-      uCrc = ((uCrc << 1) ^ POLY) & 0xFFFF
+      uCrc = ((uCrc << 1) ^ POLY16) & 0xFFFF
     } else {
       uCrc = (uCrc << 1) & 0xFFFF
     }
@@ -66,6 +82,21 @@ function calcCrc16(data, offset, uInit) {
   const msb = (uCrc >> 8) & 0xFF
   const lsb = uCrc & 0xFF
   return ((lsb << 8) | msb) & 0xFFFF
+}
+
+function calcCrc8(data, offset, initValue) {
+  let crc = (initValue ?? 0x00) & 0xFF
+  for (let i = offset ?? 0; i < data.length; i++) {
+    crc ^= data[i] & 0xFF
+    for (let bit = 0; bit < 8; bit++) {
+      if ((crc & 0x80) !== 0) {
+        crc = ((crc << 1) ^ POLY8) & 0xFF
+      } else {
+        crc = (crc << 1) & 0xFF
+      }
+    }
+  }
+  return crc & 0xFF
 }
 
 function buildFrame(messageCode, commandCode, operationCode, payload) {
@@ -87,11 +118,13 @@ function buildFrame(messageCode, commandCode, operationCode, payload) {
 }
 
 class DigiBabel {
-  constructor(matron, dev) {
+  constructor(matron, dev, options) {
     if (!didEnum) this.enum()
 
     this.matron = matron
     this.dev = dev
+    this.options = options ?? {}
+    this.debugRawHex = !!(this.options.debugRawHex ?? this.options.debug_raw_hex ?? DEBUG_RAW_HEX)
     this.sp = null // opened serial device
     this.buffer = Buffer.alloc(0) // buffer for incoming data
     this.retries = 0 // number of retries opening the device
@@ -165,6 +198,11 @@ class DigiBabel {
     
     // Hook up data parser
     sp.on("data", data => {
+      if (this.debugRawHex) {
+        const port = this.dev?.attr?.port ?? '?'
+        const ts = (Date.now() / 1000).toFixed(3)
+        console.log(`DigiBabel raw rx port ${port} ts=${ts} len=${data.length} hex=${data.toString('hex')}`)
+      }
       this.buffer = Buffer.concat([this.buffer, data])
       this.processBuffer()
     })
@@ -177,24 +215,19 @@ class DigiBabel {
     if (!this.sp || !this.sp.isOpen) return
     
     try {
-      // Send initialization message 1: command 0x0C, operation 0x01, payload 0x00
-      const msg1 = buildFrame(0x00, INIT_CMD_1, INIT_OP_1, Buffer.from([0x00]))
-      this.sp.write(msg1, (err) => {
-        if (err) {
-          console.log(`Error writing init message 1 to ${this.dev?.path}: ${err}`)
-        } else {
-          console.log(`Sent DigiBabel init message 1 to port ${this.dev.attr.port}`)
-        }
-      })
-      
-      // Send initialization message 2: command 0x0C, operation 0x00, payload 0x01
+      // Send initialization message: command 0x0C, operation 0x00, payload 0x01
       setTimeout(() => {
-        const msg2 = buildFrame(0x00, INIT_CMD_2, INIT_OP_2, Buffer.from([0x01]))
-        this.sp.write(msg2, (err) => {
+        const data = buildFrame(INIT_CODE, INIT_CMD, INIT_OP, Buffer.from([INIT_PL]))
+        if (this.debugRawHex) {
+          const port = this.dev?.attr?.port ?? '?'
+          const ts = (Date.now() / 1000).toFixed(3)
+          console.log(`DigiBabel raw tx port ${port} ts=${ts} len=${data.length} hex=${data.toString('hex')}`)
+        }
+        this.sp.write(data, (err) => {
           if (err) {
-            console.log(`Error writing init message 2 to ${this.dev?.path}: ${err}`)
+            console.log(`Error writing init message to ${this.dev?.path}: ${err}`)
           } else {
-            console.log(`Sent DigiBabel init message 2 to port ${this.dev.attr.port}`)
+            console.log(`Sent DigiBabel init message to port ${this.dev.attr.port}`)
             this.initialized = true
             this.matron.emit("devState", this.dev.attr.port, "running")
           }
@@ -262,13 +295,22 @@ class DigiBabel {
     const crcReceived = (crcBytes[0] << 8) | crcBytes[1]
     
     // Compute CRC over header + payload
+    let crcComputed = null
     const core = frame.slice(1, 5 + length)
-    const crcInit = (commandCode === TAG_DETECTION_CMD) ? 0x0500 : 0x0100
-    const crcComputed = calcCrc16(core, 0, crcInit)
+    if (commandCode == 0x82) {
+      if (length >= 6) {
+        // New schema with 6-byte payload uses CRC init 0x0600
+        crcComputed = calcCrc16(core, 0, 0x0600) }
+      else {
+        // Old schema with 5-byte payload uses CRC init 0x0500
+        crcComputed = calcCrc16(core, 0, 0x0500) }
+    } else {
+      crcComputed = calcCrc16(core, 0, 0x0100)
+    }
     
     if (crcReceived !== crcComputed) {
       console.log(`CRC mismatch in DigiBabel frame on port ${this.dev.attr.port}: ` +
-                  `received 0x${crcReceived.toString(16)}, computed 0x${crcComputed.toString(16)}`)
+                  `received 0x${crcReceived.toString(16)}, computed 0x${crcComputed.toString(16)}, core=${core.toString('hex')}`)
       return
     }
     
@@ -285,16 +327,33 @@ class DigiBabel {
   }
 
   handleTagDetection(payload) {
+    // Old payload is 5 bytes; new payload is 6 bytes.
     if (payload.length < 5) {
       console.log(`Invalid tag detection payload length on port ${this.dev.attr.port}: ${payload.length}`)
       return
     }
     
-    // Extract tag ID (bytes 0-2)
-    const tagId = payload.slice(0, 3).toString('hex')
-    
-    // Extract RSSI (byte 4)
-    const rssiRaw = payload[4]
+    // Extract tag ID (bytes 0-3)
+    const tagId = payload.slice(0, 4).toString('hex')
+
+    // New schema includes an embedded CRC byte at payload[4] and moves RSSI to payload[5].
+    // Old schema has RSSI at payload[4] and provides no embedded CRC.
+    let valid = 0
+    let rssiRaw
+    if (payload.length >= 6) {
+      const embeddedCrcReceived = payload[4] & 0xFF
+
+      // The embedded CRC is a CRC-8 over the TagID bytes (payload[0..3]).
+      const tagOnly = payload.slice(0, 4)
+      const embeddedCrcComputed8 = calcCrc8(tagOnly, 0, 0x00)
+      valid = (embeddedCrcReceived === embeddedCrcComputed8) ? 1 : 0
+
+      rssiRaw = payload[5]
+    } else {
+      // Old schema: no embedded CRC byte.
+      valid = -1
+      rssiRaw = payload[4]
+    }
     
     // Convert RSSI to dB: 10 * log10(rssiRaw / 255)
     let rssiDb
@@ -307,8 +366,8 @@ class DigiBabel {
     // Get current timestamp in seconds
     const nowSecs = Date.now() / 1000
     
-    // Build the record in the expected format: T<port>,<timestamp>,<tagid>,<rssi>
-    const lifetagRecord = `T${this.dev.attr.port},${nowSecs},${tagId},${rssiDb.toFixed(2)}`
+    // Build the record in the expected format: T<port>,<timestamp>,<tagid>,<rssi>,<valid>
+    const lifetagRecord = `T${this.dev.attr.port},${nowSecs},${tagId},${rssiDb.toFixed(2)},${valid}`
     
     // Emit the gotTag event
     this.matron.emit("gotTag", lifetagRecord)

--- a/src/digibabel.js
+++ b/src/digibabel.js
@@ -1,0 +1,325 @@
+// digibabel - manage DigiBabel UHF FSK tag receivers
+
+//   operate a DigiBabel tag receiver
+
+//   This object represents a plugged-in DigiBabel receiver. As soon as it
+//   is created, it begins recording tag detections. The device reports detections
+//   via an FTDI FT230X USB serial adapter (VID=0403, PID=6015) running at 230400 bps.babel - manage DigiBabel UHF FSK tag receivers
+
+//   operate a DigiBabel tag receiver
+
+//   This object represents a plugged-in DigiBabel receiver. As soon as it
+//   is created, it begins recording tag detections. The device reports detections
+//   via an FTDI FT232 USB serial adapter running at 230400 bps.
+//   
+//   The protocol uses a framed format:
+//     START_FLAG (0x3C '<') | LENGTH (1 byte) | MESSAGE_CODE | COMMAND_CODE | 
+//     OPERATION_CODE | PAYLOAD (N bytes) | CRC16 (2 bytes, MSB first) | STOP_FLAG (0x3E '>')
+//
+//   Tag detections have COMMAND_CODE = 0x82 and contain:
+//     - Bytes 0-2: Tag ID (3 bytes)
+//     - Byte 4: RSSI (raw 0-255 value)
+//
+//   This module watches for such frames, and emits gotTag events of the form:
+//       T[0-9]{1,2},<TS>,<ID>,<RSSI>\n
+//   where the number after 'T' is the USB port #, <TS> is the timestamp in seconds,
+//   <ID> is the 6-hex digit tag ID, and <RSSI> is the RSSI value in dB.
+
+const {SerialPort} = require('serialport')
+
+let didEnum = false
+let debugId = 1
+
+// Protocol constants
+const START_FLAG = 0x3C  // '<'
+const STOP_FLAG = 0x3E   // '>'
+const TAG_DETECTION_CMD = 0x82
+const INIT_CMD_1 = 0x0C
+const INIT_OP_1 = 0x01
+const INIT_CMD_2 = 0x0C
+const INIT_OP_2 = 0x00
+
+// CRC-16-CCITT (False) implementation
+// Polynomial: 0x1021, Init varies, RefIn/RefOut: False, XorOut: 0x0000
+const POLY = 0x1021
+
+function calcIncrCrc16(bNext, uInit) {
+  let uCrc = uInit & 0xFFFF
+  let uTemp = (bNext & 0xFF) << 8
+  uCrc ^= uTemp
+  for (let i = 0; i < 8; i++) {
+    if ((uCrc & 0x8000) !== 0) {
+      uCrc = ((uCrc << 1) ^ POLY) & 0xFFFF
+    } else {
+      uCrc = (uCrc << 1) & 0xFFFF
+    }
+  }
+  return uCrc & 0xFFFF
+}
+
+function calcCrc16(data, offset, uInit) {
+  let uCrc = uInit & 0xFFFF
+  for (let i = offset; i < data.length; i++) {
+    uCrc = calcIncrCrc16(data[i], uCrc)
+  }
+  // Lotek CRCs are little endian - swap bytes
+  const msb = (uCrc >> 8) & 0xFF
+  const lsb = uCrc & 0xFF
+  return ((lsb << 8) | msb) & 0xFFFF
+}
+
+function buildFrame(messageCode, commandCode, operationCode, payload) {
+  const N = payload.length
+  if (N > 255) {
+    throw new Error('Payload length must be <= 255')
+  }
+  
+  const head = Buffer.from([N, messageCode, commandCode, operationCode])
+  const core = Buffer.concat([head, payload])
+  const crc = calcCrc16(core, 0, 0x0100)
+  
+  return Buffer.concat([
+    Buffer.from([START_FLAG]),
+    core,
+    Buffer.from([(crc >> 8) & 0xFF, crc & 0xFF]),
+    Buffer.from([STOP_FLAG])
+  ])
+}
+
+class DigiBabel {
+  constructor(matron, dev) {
+    if (!didEnum) this.enum()
+
+    this.matron = matron
+    this.dev = dev
+    this.sp = null // opened serial device
+    this.buffer = Buffer.alloc(0) // buffer for incoming data
+    this.retries = 0 // number of retries opening the device
+    this.initialized = false // whether init messages have been sent
+
+    this.matron.on("devRemoved", (dev) => this.devRemoved(dev))
+
+    this.init_sp()
+  }
+
+  // enumerate serial ports for debugging purposes
+  enum() {
+    didEnum = true
+    SerialPort.list().then((list) => {
+      list.forEach((port) => {
+        console.log("SerialPort: " + JSON.stringify(port) + "\n")
+      })
+    })
+  }
+
+  close() {
+    if (this.sp) {
+      if (this.sp.isOpen) this.sp.close()
+      this.sp = null
+      console.log("Removed " + this.dev.path)
+    }
+  }
+
+  devRemoved(dev) {
+    if (!this.dev || dev.path != this.dev.path) return
+    this.close()
+    this.dev = null
+  }
+
+  init_sp() {
+    if (!this.dev) return // device removed
+    this.matron.emit("devState", this.dev.attr.port, "init")
+    const path = this.dev.path
+    const sp = new SerialPort({ 
+      path: path, 
+      baudRate: 230400,
+      dataBits: 8,
+      parity: 'none',
+      stopBits: 1
+    })
+    const did = debugId++
+    
+    sp.on("open", () => {
+      console.log(`Opened DigiBabel SerialPort #${did} ${path}`)
+      // Send initialization messages after a short delay
+      setTimeout(() => this.sendInitMessages(), 1000)
+    })
+    
+    sp.on("close", () => {
+      console.log(`DigiBabel SerialPort #${did} ${path} was closed`)
+      if (this.dev && !this.dev.state?.startsWith("err"))
+        this.matron.emit("devState", this.dev.attr.port, "error", "port was closed")
+    })
+    
+    sp.on("error", err => {
+      console.log(`Error on DigiBabel SerialPort #${did} ${path}: ${err.message}\nStack: ${err.stack}`)
+      if (this.dev && !this.dev.state?.startsWith("err"))
+        this.matron.emit("devState", this.dev.attr.port, "error", err.message)
+      if (sp.isOpen) sp.close()
+      if (this.retries++ < 3) {
+        setTimeout(() => {
+          this.init_sp()
+        }, this.retries < 3 ? 10000 : 60000)
+      }
+    })
+    
+    // Hook up data parser
+    sp.on("data", data => {
+      this.buffer = Buffer.concat([this.buffer, data])
+      this.processBuffer()
+    })
+    
+    this.sp = sp
+    console.log("Starting DigiBabel read stream using SerialPort at", path)
+  }
+
+  sendInitMessages() {
+    if (!this.sp || !this.sp.isOpen) return
+    
+    try {
+      // Send initialization message 1: command 0x0C, operation 0x01, payload 0x00
+      const msg1 = buildFrame(0x00, INIT_CMD_1, INIT_OP_1, Buffer.from([0x00]))
+      this.sp.write(msg1, (err) => {
+        if (err) {
+          console.log(`Error writing init message 1 to ${this.dev?.path}: ${err}`)
+        } else {
+          console.log(`Sent DigiBabel init message 1 to port ${this.dev.attr.port}`)
+        }
+      })
+      
+      // Send initialization message 2: command 0x0C, operation 0x00, payload 0x01
+      setTimeout(() => {
+        const msg2 = buildFrame(0x00, INIT_CMD_2, INIT_OP_2, Buffer.from([0x01]))
+        this.sp.write(msg2, (err) => {
+          if (err) {
+            console.log(`Error writing init message 2 to ${this.dev?.path}: ${err}`)
+          } else {
+            console.log(`Sent DigiBabel init message 2 to port ${this.dev.attr.port}`)
+            this.initialized = true
+            this.matron.emit("devState", this.dev.attr.port, "running")
+          }
+        })
+      }, 100)
+    } catch (err) {
+      console.log(`Error building init messages: ${err.message}`)
+    }
+  }
+
+  processBuffer() {
+    while (true) {
+      // Look for start flag
+      const startIdx = this.buffer.indexOf(START_FLAG)
+      if (startIdx === -1) {
+        // No start flag found, clear buffer (keep last byte in case it's a partial start)
+        if (this.buffer.length > 1) {
+          this.buffer = this.buffer.slice(-1)
+        }
+        break
+      }
+      
+      // Discard any data before the start flag
+      if (startIdx > 0) {
+        this.buffer = this.buffer.slice(startIdx)
+      }
+      
+      // Check if we have enough data for the header (1 start + 4 header bytes)
+      if (this.buffer.length < 5) {
+        break // Need more data
+      }
+      
+      // Parse header
+      const length = this.buffer[1]
+      const messageCode = this.buffer[2]
+      const commandCode = this.buffer[3]
+      const operationCode = this.buffer[4]
+      
+      // Calculate total frame length: start(1) + header(4) + payload(length) + crc(2) + stop(1)
+      const frameLength = 1 + 4 + length + 2 + 1
+      
+      if (this.buffer.length < frameLength) {
+        break // Need more data
+      }
+      
+      // Extract the complete frame
+      const frame = this.buffer.slice(0, frameLength)
+      this.buffer = this.buffer.slice(frameLength)
+      
+      // Parse the frame
+      this.parseFrame(frame, length, messageCode, commandCode, operationCode)
+    }
+  }
+
+  parseFrame(frame, length, messageCode, commandCode, operationCode) {
+    // Validate stop flag
+    if (frame[frame.length - 1] !== STOP_FLAG) {
+      console.log(`Invalid stop flag in DigiBabel frame on port ${this.dev.attr.port}`)
+      return
+    }
+    
+    // Extract payload and CRC
+    const payload = frame.slice(5, 5 + length)
+    const crcBytes = frame.slice(5 + length, 5 + length + 2)
+    const crcReceived = (crcBytes[0] << 8) | crcBytes[1]
+    
+    // Compute CRC over header + payload
+    const core = frame.slice(1, 5 + length)
+    const crcInit = (commandCode === TAG_DETECTION_CMD) ? 0x0500 : 0x0100
+    const crcComputed = calcCrc16(core, 0, crcInit)
+    
+    if (crcReceived !== crcComputed) {
+      console.log(`CRC mismatch in DigiBabel frame on port ${this.dev.attr.port}: ` +
+                  `received 0x${crcReceived.toString(16)}, computed 0x${crcComputed.toString(16)}`)
+      return
+    }
+    
+    // Process based on command code
+    if (commandCode === TAG_DETECTION_CMD) {
+      this.handleTagDetection(payload)
+    } else {
+      // Other command responses (could be init responses, status, etc.)
+      console.log(`DigiBabel response on port ${this.dev.attr.port}: ` +
+                  `cmd=0x${commandCode.toString(16).padStart(2, '0')}, ` +
+                  `op=0x${operationCode.toString(16).padStart(2, '0')}, ` +
+                  `payload=${payload.toString('hex')}`)
+    }
+  }
+
+  handleTagDetection(payload) {
+    if (payload.length < 5) {
+      console.log(`Invalid tag detection payload length on port ${this.dev.attr.port}: ${payload.length}`)
+      return
+    }
+    
+    // Extract tag ID (bytes 0-2)
+    const tagId = payload.slice(0, 3).toString('hex')
+    
+    // Extract RSSI (byte 4)
+    const rssiRaw = payload[4]
+    
+    // Convert RSSI to dB: 10 * log10(rssiRaw / 255)
+    let rssiDb
+    if (rssiRaw > 0) {
+      rssiDb = 10 * Math.log10(rssiRaw / 255)
+    } else {
+      rssiDb = -Infinity
+    }
+    
+    // Get current timestamp in seconds
+    const nowSecs = Date.now() / 1000
+    
+    // Build the record in the expected format: T<port>,<timestamp>,<tagid>,<rssi>
+    const lifetagRecord = `T${this.dev.attr.port},${nowSecs},${tagId},${rssiDb.toFixed(2)}`
+    
+    // Emit the gotTag event
+    this.matron.emit("gotTag", lifetagRecord)
+    
+    // Write to the LifeTag output stream (CTT format)
+    if (typeof LifetagOut !== 'undefined') {
+      LifetagOut.write(lifetagRecord + "\n")
+    }
+    
+    console.log(`DigiBabel tag: ${lifetagRecord}`)
+  }
+}
+
+module.exports = DigiBabel

--- a/src/digibabel.js
+++ b/src/digibabel.js
@@ -99,6 +99,11 @@ function calcCrc8(data, offset, initValue) {
   return crc & 0xFF
 }
 
+function crcInitFromPayloadLength(length) {
+  // The USB CRC init depends on the payload length in this way: 0x{length}00.
+  return ((length & 0xFF) << 8) & 0xFFFF
+}
+
 function buildFrame(messageCode, commandCode, operationCode, payload) {
   const N = payload.length
   if (N > 255) {
@@ -107,7 +112,7 @@ function buildFrame(messageCode, commandCode, operationCode, payload) {
   
   const head = Buffer.from([N, messageCode, commandCode, operationCode])
   const core = Buffer.concat([head, payload])
-  const crc = calcCrc16(core, 0, 0x0100)
+  const crc = calcCrc16(core, 0, crcInitFromPayloadLength(N))
   
   return Buffer.concat([
     Buffer.from([START_FLAG]),
@@ -294,19 +299,9 @@ class DigiBabel {
     const crcBytes = frame.slice(5 + length, 5 + length + 2)
     const crcReceived = (crcBytes[0] << 8) | crcBytes[1]
     
-    // Compute CRC over header + payload
-    let crcComputed = null
+    // Compute CRC over header + payload using init=0x{payloadLength}00
     const core = frame.slice(1, 5 + length)
-    if (commandCode == 0x82) {
-      if (length >= 6) {
-        // New schema with 6-byte payload uses CRC init 0x0600
-        crcComputed = calcCrc16(core, 0, 0x0600) }
-      else {
-        // Old schema with 5-byte payload uses CRC init 0x0500
-        crcComputed = calcCrc16(core, 0, 0x0500) }
-    } else {
-      crcComputed = calcCrc16(core, 0, 0x0100)
-    }
+    const crcComputed = calcCrc16(core, 0, crcInitFromPayloadLength(length))
     
     if (crcReceived !== crcComputed) {
       console.log(`CRC mismatch in DigiBabel frame on port ${this.dev.attr.port}: ` +

--- a/src/hubman.js
+++ b/src/hubman.js
@@ -100,6 +100,8 @@ class HubMan {
         // temporary hacks, need to change uDev rules instead
         if (attr.type.includes("Cornell")) attr.type = "CTT/CornellRcvr"
         if (attr.type.includes("Cornell")) attr.radio = "CTT/Cornell"
+        if (attr.type.includes("DigiBabel")) attr.type = "DigiBabel"
+        if (attr.type.includes("DigiBabel")) attr.radio = "DigiBabel"
         if (attr.type.includes("funcube")) attr.radio = "VAH"
         if (attr.type.includes("rtlsdr")) attr.radio = "VAH"
 

--- a/src/main.js
+++ b/src/main.js
@@ -170,7 +170,7 @@ Dashboard.start()
 
 // Start the tagFinder
 PulseFilter.start()
-BurstFinder.start()
+// BurstFinder.start()
 TagFinder.start()
 
 MotusUp.start()

--- a/src/main.js
+++ b/src/main.js
@@ -74,6 +74,7 @@ Sensor        = require('./sensor.js');
 USBAudio      = require("./usbaudio.js");
 RTLSDR        = require("./rtlsdr.js");
 CornellTagXCVR= require("./cornelltagxcvr.js");
+DigiBabel     = require("./digibabel.js");
 
 //WavMaker      = require('./wavmaker.js');
 

--- a/src/matron.js
+++ b/src/matron.js
@@ -35,6 +35,11 @@ Matron.prototype.devAdded = function(dev) {
     if (dev.attr.type == "CTT/CornellRcvr") {
         this.devices[dev.attr.port] = new CornellTagXCVR(this, dev, null);
     }
+    
+    // for DigiBabel, we don't require or use a plan
+    if (dev.attr.type == "DigiBabel") {
+        this.devices[dev.attr.port] = new DigiBabel(this, dev, null);
+    }
 };
 
 Matron.prototype.devRemoved = function(dev) {


### PR DESCRIPTION
Added:
- src/digibabel.js: handles initialization and communication with the DigiBabel receiver, based on cornelltagxcvr.js
- rules.d/20-usb-hub-devices.rules: contains the udev rules needed for DigiBabel compatibility (must be installed under /etc/udev/rules.d

Modified:
- hubman.js: minimal changes to support the DigiBabel device
- main.js: same as above
- matron.js: same as above

Edit: support has now been added for the latest version of the DigiBabel which provides the embedded LifeTag CRC (calculated on the TagID) as well as the USB CRC (calculated on the USB message header+payload). The latest code checks the CRC validity and includes the result in a new <valid> column at the end of each lifetag record, with the format: T<port>,<timestamp>,<tagid>,<rssi>,<valid>

The possible values of <valid> are:
1: CRC is valid
0: CRC is not valid
-1: CRC is not present (i.e. the device is running old DigiBabel firmware)